### PR TITLE
fix: set stable dependency versions for Python 3.10 (pdfplumber 0.11.…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,12 @@
 streamlit==1.36.0
 pandas==2.2.2
 openpyxl==3.1.2
-pdfplumber==0.11.7
-pdfminer.six==20231228
+pdfplumber==0.11.4
+pdfminer.six==20221105
 Pillow==10.2.0
 rapidfuzz==3.6.1
 python-dateutil==2.9.0.post0
+markdown-it-py==3.0.0
+mdurl==0.1.2
+rich==14.1.0
+pygments==2.19.1


### PR DESCRIPTION
Pin and update dependencies to ensure compatibility with Python 3.13 and fix unsatisfiable requirements.