### PR TITLE
fix: remove unused dependencies to resolve install failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,3 @@ pdfminer.six==20221105
 Pillow==10.2.0
 rapidfuzz==3.6.1
 python-dateutil==2.9.0.post0
-markdown-it-py==3.0.0
-mdurl==0.1.2
-rich==14.1.0
-pygments==2.19.1


### PR DESCRIPTION
Removed markdown-it-py, mdurl, rich, pygments from requirements since they cause build loops; keep essential dependencies only.