### PR TITLE
fix: remove pdfminer.six to resolve dependency conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ streamlit==1.36.0
 pandas==2.2.2
 openpyxl==3.1.2
 pdfplumber==0.11.4
-pdfminer.six==20221105
 Pillow==10.2.0
 rapidfuzz==3.6.1
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
Remove pdfminer.six version pin; letting pdfplumber install its required pdfminer.six (likely 20231228). This resolves the dependency conflict during installation.