### PR TITLE
feat: remove catalog uploader and use sales history as catalog

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,7 +15,7 @@ try:
     from matcher.matcher import (
         load_order_pdf, load_order_excel,
         _build_customer_stats, match_order_to_catalog,
-        export_sap_excel
+        export_sap_excel,
     )
 except Exception as e:
     MATCHER_OK = False
@@ -56,8 +56,10 @@ with tab_order:
     # Diagnostica se il matcher non è importabile
     if not MATCHER_OK:
         with st.expander("Diagnostica import matcher (clicca per dettagli)", expanded=True):
-            st.warning("Il modulo di matching non è stato importato. "
-                       "Procedo con **funzionalità ridotte** (Excel→Excel).")
+            st.warning(
+                "Il modulo di matching non è stato importato. "
+                "Procedo con **funzionalità ridotte** (Excel→Excel)."
+            )
             st.code(IMPORT_ERROR or "Nessun dettaglio disponibile", language="text")
 
     # Stato dipendenze
@@ -66,24 +68,26 @@ with tab_order:
     colB.metric("Fuzzy match (rapidfuzz)", "OK" if HAS_FUZZ else "NON DISPONIBILE")
     colC.metric("Modulo matcher", "OK" if MATCHER_OK else "IMPORT FALLITO")
 
-    # Uploaders SEMPRE disponibili
+    # Uploaders: ordine e storico vendite
     up_order = st.file_uploader(
         "Carica ordine (PDF o Excel)",
         type=(["pdf"] if HAS_PDF else []) + ["xlsx", "xls", "csv"],
-        help="Se il supporto PDF non è disponibile, usa Excel/CSV."
+        help="Se il supporto PDF non è disponibile, usa Excel/CSV.",
     )
-    up_sales = st.file_uploader("Carica storico vendite (Excel/CSV)", type=["xlsx", "xls", "csv"], key="sales_hist")
-    up_catalog = st.file_uploader("Carica catalogo prodotti (Excel/CSV)", type=["xlsx", "xls", "csv"], key="catalog")
+    up_sales = st.file_uploader(
+        "Carica storico vendite (Excel/CSV)", type=["xlsx", "xls", "csv"], key="sales_hist"
+    )
     sel_customer = st.text_input("CardCode Cliente (opzionale)", value="")
 
-    # Helpers lettura
+    # Helpers per la lettura dei file
     def read_table(file):
+        """Leggi un file CSV o Excel in un DataFrame."""
         name = file.name.lower()
         if name.endswith(".csv"):
             return pd.read_csv(file)
         return pd.read_excel(file)
 
-    # Caricamento dati
+    # Caricamento dell'ordine
     order_df = None
     if up_order is not None and MATCHER_OK:
         if up_order.name.lower().endswith(".pdf") and HAS_PDF:
@@ -94,16 +98,17 @@ with tab_order:
             else:
                 st.error("Formato non supportato senza pdfplumber. Usa Excel/CSV.")
     elif up_order is not None and not MATCHER_OK:
-        # Fallback duro: prova a leggere Excel/CSV anche senza matcher
+        # Fallback: prova a leggere l'ordine come Excel/CSV anche senza matcher
         if up_order.name.lower().endswith((".xlsx", ".xls", ".csv")):
             try:
                 order_df = read_table(up_order)
-                # Normalizzazione minima
+                # Normalizzazione minima dei nomi colonna
                 lc = {c: c.lower() for c in order_df.columns}
                 order_df.rename(columns=lc, inplace=True)
             except Exception as e:
                 st.error(f"Impossibile leggere l'ordine: {e}")
 
+    # Caricamento dello storico vendite
     sales_df = None
     if up_sales is not None:
         try:
@@ -111,20 +116,20 @@ with tab_order:
         except Exception as e:
             st.error(f"Storico non leggibile: {e}")
 
-    catalog_df = None
-    if up_catalog is not None:
-        try:
-            catalog_df = read_table(up_catalog)
-        except Exception as e:
-            st.error(f"Catalogo non leggibile: {e}")
+    # Usa lo storico vendite anche come catalogo per il matching
+    catalog_df = sales_df
 
-    # Matching
-    if order_df is not None and catalog_df is not None and MATCHER_OK:
+    # Matching solo se ordine e storico sono disponibili e il matcher è operativo
+    if order_df is not None and sales_df is not None and MATCHER_OK:
         st.caption("Anteprima ordine")
         st.dataframe(order_df.head(30), use_container_width=True)
 
-        stats = _build_customer_stats(sales_df if sales_df is not None else pd.DataFrame(), sel_customer or None)
+        # Calcolo delle statistiche cliente (se disponibile)
+        stats = _build_customer_stats(
+            sales_df if sales_df is not None else pd.DataFrame(), sel_customer or None
+        )
 
+        # Esegui il matching tra ordine e catalogo (storico vendite)
         try:
             matched = match_order_to_catalog(order_df, catalog_df, stats)
         except Exception as e:
@@ -135,7 +140,7 @@ with tab_order:
             st.success("Matching completato.")
             st.dataframe(matched, use_container_width=True)
 
-            # Export SAP
+            # Sezione export SAP
             with st.form("export_form"):
                 st.caption("Parametri export SAP (minimali)")
                 header = {
@@ -151,12 +156,16 @@ with tab_order:
                             "Scarica file Excel",
                             data=BytesIO(data),
                             file_name="SAP_ORDR_RDR1.xlsx",
-                            mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                            mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                         )
                     except Exception as e:
                         st.error(f"Errore export: {e}")
+
     elif order_df is None:
-        st.info("Carica **ordine** (PDF se disponibile o Excel/CSV) e **catalogo** per procedere.")
+        # Messaggio informativo se manca l'ordine
+        st.info(
+            "Carica **ordine** (PDF se disponibile o Excel/CSV) e **storico vendite** per procedere."
+        )
 
 with tab_xsell:
     st.info("Scheda Cross-sell (placeholder)")


### PR DESCRIPTION
This update removes the catalog file uploader from the Import Ordine Cliente tab and uses the sales history file as the product catalog for matching. Matching now runs as soon as both order and sales history are uploaded.